### PR TITLE
Wrong result when taxable income becomes too large

### DIFF
--- a/FinalProject--Python.py
+++ b/FinalProject--Python.py
@@ -114,13 +114,9 @@ def oldtax(ta):
                 total = total + 250000 * 20 / 100
             else:
                 total = total + ta * 20 / 100
-        elif n == 4 or n == 5:
-            if ta >= 250000:
-                total = total + 250000 * 30 / 100
-            else:
-                total = total + ta * 30 / 100
-        elif n == 6:
+        elif n == 4 :
             total = total + ta * 30 / 100
+            break
         else:
             total = 0
         ta = ta - 250000
@@ -160,6 +156,7 @@ def newtax(ta):
                 total = total + ta * 25 / 100
         elif n == 6:
             total = total + ta * 30 / 100
+            break
         else:
             total = 0
         ta = ta - 250000


### PR DESCRIPTION
#### ISSUE #10 
fixes # 2
<!-- Please Mention the issue number as  ISSUE #(Issue Number)
Example:
ISSUE #5
-->

#### Describe the changes you've made
In old tax function ,
after n==4 , now there is no need to break salary into divisions of 2,50,000 so applied a tax of 30% on total salary left at n==4 and then applied break
in case of new tax function,
after n==6,now there is no need to break salary into divisions of 2,50,000 so applied a tax of 30% on total salary left at n==6 and then applied break.

in previous code the bug was that if income  became extra large, then n becomes greater than 6 and hence 'else' statement was executed and thus total was showing zero

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

#### Additional context (OPTIONAL)
Add any other context or screenshots about the feature request here.

#### Test plan (OPTIONAL)
A good test plan should give instructions that someone else can easily follow.
How someone can test your code?

#### Checklist
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] I have added my name in the contributors list at the end of README.md file.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] The title of my pull request is a short description of the requested changes.
- [ ] Open Source Program names(OPTIONAL: If you participated in any open-source program then please mention the program name here)
