### PR TITLE
Fixed the another bug with sending email

### DIFF
--- a/FinalProject--Python.py
+++ b/FinalProject--Python.py
@@ -20,11 +20,11 @@ pyglet.gl.glClearColor(r,g,b,alpha)
 @win.event
 
 def on_draw():
-	win.clear()
-	animSprite.draw()
+    win.clear()
+    animSprite.draw()
 
 def close(event):
-	win.close()
+    win.close()
 
 pyglet.clock.schedule_once(close,5.0)
 

--- a/FinalProject--Python.py
+++ b/FinalProject--Python.py
@@ -367,9 +367,9 @@ def send_message():
     finalMessage='Subject: {}\n\n{} '.format(subject,email_body_info)
     server=smtplib.SMTP_SSL("smtp.gmail.com",465)
     server.login(sender_email,sender_pass)
-    print("Login successfull")
+    mbox.showinfo("Status","Login Successfull!")
     server.sendmail(sender_email,to,finalMessage)
-    print("Message sent")
+    mbox.showinfo("Status","Message Sent!")
 
 def delete():
     l8 = Label(f3, text="                                                                                         ",
@@ -486,10 +486,11 @@ def sharemail():
     elif (flag == False):
         mbox.showerror("Error", "You haven't calculated yet.")
     else:
-        a=messagebox.showinfo("User's tax info ",f"Name: {myname.get()} \n\n Income Tax calculation is: \n\n Oldtax: {old}  Newtax: {new}  Taxsave: {tax_save}")
-        if a=="ok":
+        a=mbox.askokcancel("Share this User's Tax Info", f"Name: {myname.get()} \n\nIncome Tax calculation is: \nOldtax: {old}\nNewtax: {new}\nTaxsave: {tax_save}\n\n" + "Do you want to share this details?")
+        if a:
             send_message()
-
+        else:
+            mbox.showinfo("Status", "Message Not Sent!")
 
 def credit():
     messagebox.showinfo('Credits',


### PR DESCRIPTION
#### Issue Number
fixes #126

#### Describe the changes you've made
here i have implemented the share with email button to send message only when we click ok, other wise not.
And also instead of print statement displayed message box instead.

for eg.
below is what we get when we click on share with email button,
![1](https://user-images.githubusercontent.com/57003737/122522444-9cf2cf00-d033-11eb-8a9a-f43637876662.jpg)

Now if we click on OK, we get following two message of sharing process,
![2](https://user-images.githubusercontent.com/57003737/122522568-be53bb00-d033-11eb-86ca-c5baf2db97c8.jpg)
![3](https://user-images.githubusercontent.com/57003737/122522579-c0b61500-d033-11eb-9898-7ff14d2fe39c.jpg)

And if we click on cancel , we get the message that message is not sent.
![4](https://user-images.githubusercontent.com/57003737/122522649-d3c8e500-d033-11eb-9ef1-94b67ce94dbb.jpg)



#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

#### Checklist
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] I have added my name in the contributors list at the end of README.md file.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
- [ ] Open Source Program names(OPTIONAL: If you participated in any open-source program then please mention the program name here)
